### PR TITLE
FCS rotation was 90 degrees off

### DIFF
--- a/components/falcons/getball-fetch/testdata/kickoff_prepare.json
+++ b/components/falcons/getball-fetch/testdata/kickoff_prepare.json
@@ -1,5 +1,5 @@
 {
     "Input": "testdata/worldstate_kickoff_prepare.json",
-    "Output": {"actionresult": "RUNNING", "target": {"position": {"x": 0.07, "y": -0.02, "rz": 3.19057298}}}
+    "Output": {"actionresult": "RUNNING", "target": {"position": {"x": 0.07, "y": -0.02, "rz": 1.61977673}}}
 }
 

--- a/components/falcons/getball-fetch/tick.cpp
+++ b/components/falcons/getball-fetch/tick.cpp
@@ -74,7 +74,7 @@ int FalconsGetballFetch::FalconsGetballFetch::tick
 
             // set target, robot facing angle towards ball
             MRA::Datatypes::Pose current = ws.robot().position();
-            target.set_rz(geometry::calc_rz_between(current, target));
+            target.set_rz(geometry::calc_facing_angle_fcs(current, target));
 
             // write output
             output.mutable_target()->mutable_position()->set_x(target.x());

--- a/libraries/geometry/geometry.cpp
+++ b/libraries/geometry/geometry.cpp
@@ -8,9 +8,9 @@ double MRA::geometry::vectorsize(MRA::Datatypes::Pose const &p)
 }
 
 // relative angle
-double MRA::geometry::calc_rz_between(MRA::Datatypes::Pose const &from, MRA::Datatypes::Pose const &to)
+double MRA::geometry::calc_facing_angle_fcs(MRA::Datatypes::Pose const &from, MRA::Datatypes::Pose const &to)
 {
-    return clip_rot(atan2(to.y() - from.y(), to.x() - from.x()));
+    return clip_rot(atan2(to.y() - from.y(), to.x() - from.x()) - 0.5 * M_PI);
 }
 
 // clip rotation/angle to [0, 2pi) according to MSL coordinate system specification

--- a/libraries/geometry/geometry.hpp
+++ b/libraries/geometry/geometry.hpp
@@ -9,8 +9,10 @@ namespace MRA::geometry
 // vectorsize: sqrt(x*x + y*y + z*z)
 double vectorsize(MRA::Datatypes::Pose const &p);
 
-// relative angle
-double calc_rz_between(MRA::Datatypes::Pose const &from, MRA::Datatypes::Pose const &to);
+// relative angle in MSL-FCS, where 0 is facing opponent goal
+// (which is 90 degrees rotated w.r.t. regular polar coordinate system)
+// example: when robot at x=2 takes a kickoff, the angle towards ball is 0.5*pi
+double calc_facing_angle_fcs(MRA::Datatypes::Pose const &from, MRA::Datatypes::Pose const &to);
 
 } // namespace MRA::geometry
 

--- a/testdata/worldstate_kickoff_prepare.json
+++ b/testdata/worldstate_kickoff_prepare.json
@@ -1,11 +1,13 @@
 {
     "worldstate":
     {
-        "robot": {"id": 1, "active": true, "position": {"x": -0.01, "y": -8.69, "rz":  1.62}, "hasball": false},
-        "robot": {"id": 2, "active": true, "position": {"x":  1.53, "y": -2.93, "rz":  1.22}, "hasball": false},
-        "robot": {"id": 3, "active": true, "position": {"x":  0.70, "y": -6.02, "rz":  1.68}, "hasball": false},
-        "robot": {"id": 4, "active": true, "position": {"x": -2.02, "y": -0.03, "rz":  0.01}, "hasball": false},
-        "robot": {"id": 5, "active": true, "position": {"x":  1.09, "y":  0.03, "rz":  3.14}, "hasball": false},
+        "robot": {"id": 5, "active": true, "position": {"x":  1.09, "y":  0.03, "rz":  1.64}, "hasball": false},
+        "teammates": [
+            {"id": 1, "active": true, "position": {"x": -0.01, "y": -8.69, "rz":  0.12}, "hasball": false},
+            {"id": 2, "active": true, "position": {"x":  1.53, "y": -2.93, "rz": -0.32}, "hasball": false},
+            {"id": 3, "active": true, "position": {"x":  0.70, "y": -6.02, "rz":  0.18}, "hasball": false},
+            {"id": 4, "active": true, "position": {"x": -2.02, "y": -0.03, "rz":  0.01}, "hasball": false}
+        ],
         "ball": {"position": {"x": 0.07, "y": -0.02}}
     }
 }


### PR DESCRIPTION
I didn't find it earlier because I tested in Falcons code that used the same (wrong) coordinate system definition.

Let's use official MSL standard from now on.

The utility function `calc_facing_angle_fcs` can be used for instance to let robot face the ball (or any other position).