### PR TITLE
falcons/getball-fetch interface change: remove slow/motionProfile

### DIFF
--- a/components/falcons/getball-fetch/interface/Input.proto
+++ b/components/falcons/getball-fetch/interface/Input.proto
@@ -7,6 +7,6 @@ import "datatypes/WorldState.proto";
 message Input
 {
     MRA.Datatypes.WorldState worldstate = 1;
-    bool slow = 2;
+    int32 motionProfile = 2;
 }
 

--- a/components/falcons/getball-fetch/interface/Input.proto
+++ b/components/falcons/getball-fetch/interface/Input.proto
@@ -7,6 +7,5 @@ import "datatypes/WorldState.proto";
 message Input
 {
     MRA.Datatypes.WorldState worldstate = 1;
-    int32 motionProfile = 2;
 }
 

--- a/components/falcons/getball-fetch/interface/Output.proto
+++ b/components/falcons/getball-fetch/interface/Output.proto
@@ -9,6 +9,6 @@ message Output
 {
     MRA.Datatypes.ActionResult actionresult = 1;
     MRA.Datatypes.PosVel target = 2; // in FCS
-    //bool slow = 3; // TODO: not so nice to see slow just passing through ... ? bypass, or include in target, or ...?
+    int32 motionProfile = 3; // just passing through the input
 }
 

--- a/components/falcons/getball-fetch/interface/Output.proto
+++ b/components/falcons/getball-fetch/interface/Output.proto
@@ -9,6 +9,5 @@ message Output
 {
     MRA.Datatypes.ActionResult actionresult = 1;
     MRA.Datatypes.PosVel target = 2; // in FCS
-    int32 motionProfile = 3; // just passing through the input
 }
 

--- a/components/falcons/getball-fetch/tick.cpp
+++ b/components/falcons/getball-fetch/tick.cpp
@@ -77,7 +77,6 @@ int FalconsGetballFetch::FalconsGetballFetch::tick
             target.faceAwayFrom(ws.robot().position());
 
             // write output
-            output.set_motionprofile(input.motionprofile());
             output.mutable_target()->mutable_position()->set_x(target.x);
             output.mutable_target()->mutable_position()->set_y(target.y);
             output.mutable_target()->mutable_position()->set_rz(target.rz);

--- a/components/falcons/getball-fetch/tick.cpp
+++ b/components/falcons/getball-fetch/tick.cpp
@@ -77,6 +77,7 @@ int FalconsGetballFetch::FalconsGetballFetch::tick
             target.faceAwayFrom(ws.robot().position());
 
             // write output
+            output.set_motionprofile(input.motionprofile());
             output.mutable_target()->mutable_position()->set_x(target.x);
             output.mutable_target()->mutable_position()->set_y(target.y);
             output.mutable_target()->mutable_position()->set_rz(target.rz);


### PR DESCRIPTION
In Falcons code the motionProfile is an input to getball action.
But the getball action does not use it, instead it is used as context for velocityControl.

The use cases are:
1. main: aggressive getball during normal play
2. slow-but-accurate getball during setpiece-prepare, when no opponent threat is present

Solution directions:
a. pass through motionProfile
b. not have it on the interface of getball-fetch

I now prefer b). Jurge, what do you think? 
Does it fit with your ideas of the interface of this particular component?
Does the MRA architecture (diagrams) allow bypassing components?