### PR TITLE
Fix timestamps

### DIFF
--- a/base/abstract_interface.hpp
+++ b/base/abstract_interface.hpp
@@ -1,6 +1,8 @@
 #ifndef _MRA_BASE_ABSTRACT_INTERFACE_HPP
 #define _MRA_BASE_ABSTRACT_INTERFACE_HPP
 
+#include <google/protobuf/util/time_util.h>
+
 namespace MRA
 {
 
@@ -19,12 +21,12 @@ public:
     ~MRAInterface() {};
 
     virtual int tick(
-        double            timestamp,   // simulation timestamp, seconds since start of simulation
-        InputType  const &input,       // input data, type generated from Input.proto
-        ParamsType const &params,      // configuration parameters, type generated from Params.proto
-        StateType        &state,       // state data, type generated from State.proto
-        OutputType       &output,      // output data, type generated from Output.proto
-        LocalType        &local        // local/diagnostics data, type generated from Local.proto
+        google::protobuf::Timestamp timestamp,   // absolute timestamp
+        InputType  const           &input,       // input data, type generated from Input.proto
+        ParamsType const           &params,      // configuration parameters, type generated from Params.proto
+        StateType                  &state,       // state data, type generated from State.proto
+        OutputType                 &output,      // output data, type generated from Output.proto
+        LocalType                  &local        // local/diagnostics data, type generated from Local.proto
     ) = 0;
 
 }; // template class MRAInterface

--- a/base/codegen/template_instance.hpp
+++ b/base/codegen/template_instance.hpp
@@ -24,12 +24,12 @@ public:
 
     // user implementation
     int tick(
-        double            timestamp,   // simulation timestamp, seconds since start of simulation
-        InputType  const &input,       // input data, type generated from Input.proto
-        ParamsType const &params,      // configuration parameters, type generated from Params.proto
-        StateType        &state,       // state data, type generated from State.proto
-        OutputType       &output,      // output data, type generated from Output.proto
-        LocalType        &local        // local/diagnostics data, type generated from Local.proto
+        google::protobuf::Timestamp timestamp,   // absolute timestamp
+        InputType  const           &input,       // input data, type generated from Input.proto
+        ParamsType const           &params,      // configuration parameters, type generated from Params.proto
+        StateType                  &state,       // state data, type generated from State.proto
+        OutputType                 &output,      // output data, type generated from Output.proto
+        LocalType                  &local        // local/diagnostics data, type generated from Local.proto
     );
 
     // make default configuration easily accessible
@@ -44,7 +44,7 @@ public:
         StateType s;
         OutputType o;
         LocalType l;
-        return tick(0.0, InputType(), defaultParams(), s, o, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), InputType(), defaultParams(), s, o, l);
     };
 
     int tick(
@@ -54,7 +54,7 @@ public:
     {
         StateType s;
         LocalType l;
-        return tick(0.0, input, defaultParams(), s, output, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, defaultParams(), s, output, l);
     };
 
     int tick(
@@ -65,7 +65,18 @@ public:
     {
         StateType s;
         LocalType l;
-        return tick(0.0, input, params, s, output, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, params, s, output, l);
+    };
+
+    int tick(
+        InputType  const &input,
+        ParamsType const &params,
+        StateType        &state,
+        OutputType       &output,
+        LocalType        &local
+    )
+    {
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, params, state, output, local);
     };
 
 }; // class COMPONENT_CPP_NAME_CAMELCASE

--- a/base/codegen/template_tick.cpp
+++ b/base/codegen/template_tick.cpp
@@ -12,12 +12,12 @@ using namespace MRA;
 
 int COMPONENT_CPP_NAME_CAMELCASE::COMPONENT_CPP_NAME_CAMELCASE::tick
 (
-    double            timestamp,   // simulation timestamp, seconds since start of simulation
-    InputType  const &input,       // input data, type generated from Input.proto
-    ParamsType const &params,      // configuration parameters, type generated from Params.proto
-    StateType        &state,       // state data, type generated from State.proto
-    OutputType       &output,      // output data, type generated from Output.proto
-    LocalType        &local        // local/diagnostics data, type generated from Local.proto
+    google::protobuf::Timestamp timestamp,   // absolute timestamp
+    InputType  const           &input,       // input data, type generated from Input.proto
+    ParamsType const           &params,      // configuration parameters, type generated from Params.proto
+    StateType                  &state,       // state data, type generated from State.proto
+    OutputType                 &output,      // output data, type generated from Output.proto
+    LocalType                  &local        // local/diagnostics data, type generated from Local.proto
 )
 {
     int error_value = 0;

--- a/base/test_factory.hpp
+++ b/base/test_factory.hpp
@@ -32,7 +32,7 @@ typename Tc::OutputType run_testvector(std::string tv_filename)
     convert_json_to_proto(j, "Output", expected_output);
 
     // Act - tick
-    int error_value = m.tick(0.0, input, params, state, actual_output, local);
+    int error_value = m.tick(input, params, state, actual_output, local);
 
     // Assert
     EXPECT_EQ(error_value, 0);

--- a/components/falcons/getball/FalconsGetball.hpp
+++ b/components/falcons/getball/FalconsGetball.hpp
@@ -29,12 +29,12 @@ public:
 
     // user implementation
     int tick(
-        double            timestamp,   // simulation timestamp, seconds since start of simulation
-        InputType  const &input,       // input data, type generated from Input.proto
-        ParamsType const &params,      // configuration parameters, type generated from Params.proto
-        StateType        &state,       // state data, type generated from State.proto
-        OutputType       &output,      // output data, type generated from Output.proto
-        LocalType        &local        // local/diagnostics data, type generated from Local.proto
+        google::protobuf::Timestamp timestamp,   // absolute timestamp
+        InputType  const           &input,       // input data, type generated from Input.proto
+        ParamsType const           &params,      // configuration parameters, type generated from Params.proto
+        StateType                  &state,       // state data, type generated from State.proto
+        OutputType                 &output,      // output data, type generated from Output.proto
+        LocalType                  &local        // local/diagnostics data, type generated from Local.proto
     );
 
     // make default configuration easily accessible
@@ -49,7 +49,7 @@ public:
         StateType s;
         OutputType o;
         LocalType l;
-        return tick(0.0, InputType(), defaultParams(), s, o, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), InputType(), defaultParams(), s, o, l);
     };
 
     int tick(
@@ -59,7 +59,7 @@ public:
     {
         StateType s;
         LocalType l;
-        return tick(0.0, input, defaultParams(), s, output, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, defaultParams(), s, output, l);
     };
 
     int tick(
@@ -70,7 +70,18 @@ public:
     {
         StateType s;
         LocalType l;
-        return tick(0.0, input, params, s, output, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, params, s, output, l);
+    };
+
+    int tick(
+        InputType  const &input,
+        ParamsType const &params,
+        StateType        &state,
+        OutputType       &output,
+        LocalType        &local
+    )
+    {
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, params, state, output, local);
     };
 
 }; // class FalconsGetball

--- a/components/falcons/getball/tick.cpp
+++ b/components/falcons/getball/tick.cpp
@@ -16,12 +16,12 @@ using namespace MRA;
 
 int FalconsGetball::FalconsGetball::tick
 (
-    double            timestamp,   // simulation timestamp, seconds since start of simulation
-    InputType  const &input,       // input data, type generated from Input.proto
-    ParamsType const &params,      // configuration parameters, type generated from Params.proto
-    StateType        &state,       // state data, type generated from State.proto
-    OutputType       &output,      // output data, type generated from Output.proto
-    LocalType        &local        // local/diagnostics data, type generated from Local.proto
+    google::protobuf::Timestamp timestamp,   // absolute timestamp
+    InputType  const           &input,       // input data, type generated from Input.proto
+    ParamsType const           &params,      // configuration parameters, type generated from Params.proto
+    StateType                  &state,       // state data, type generated from State.proto
+    OutputType                 &output,      // output data, type generated from Output.proto
+    LocalType                  &local        // local/diagnostics data, type generated from Local.proto
 )
 {
     int error_value = 0;

--- a/components/falcons/getball_fetch/FalconsGetballFetch.hpp
+++ b/components/falcons/getball_fetch/FalconsGetballFetch.hpp
@@ -29,12 +29,12 @@ public:
 
     // user implementation
     int tick(
-        double            timestamp,   // simulation timestamp, seconds since start of simulation
-        InputType  const &input,       // input data, type generated from Input.proto
-        ParamsType const &params,      // configuration parameters, type generated from Params.proto
-        StateType        &state,       // state data, type generated from State.proto
-        OutputType       &output,      // output data, type generated from Output.proto
-        LocalType        &local        // local/diagnostics data, type generated from Local.proto
+        google::protobuf::Timestamp timestamp,   // absolute timestamp
+        InputType  const           &input,       // input data, type generated from Input.proto
+        ParamsType const           &params,      // configuration parameters, type generated from Params.proto
+        StateType                  &state,       // state data, type generated from State.proto
+        OutputType                 &output,      // output data, type generated from Output.proto
+        LocalType                  &local        // local/diagnostics data, type generated from Local.proto
     );
 
     // make default configuration easily accessible
@@ -49,7 +49,7 @@ public:
         StateType s;
         OutputType o;
         LocalType l;
-        return tick(0.0, InputType(), defaultParams(), s, o, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), InputType(), defaultParams(), s, o, l);
     };
 
     int tick(
@@ -59,7 +59,7 @@ public:
     {
         StateType s;
         LocalType l;
-        return tick(0.0, input, defaultParams(), s, output, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, defaultParams(), s, output, l);
     };
 
     int tick(
@@ -70,7 +70,18 @@ public:
     {
         StateType s;
         LocalType l;
-        return tick(0.0, input, params, s, output, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, params, s, output, l);
+    };
+
+    int tick(
+        InputType  const &input,
+        ParamsType const &params,
+        StateType        &state,
+        OutputType       &output,
+        LocalType        &local
+    )
+    {
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, params, state, output, local);
     };
 
 }; // class FalconsGetballFetch

--- a/components/falcons/getball_fetch/tick.cpp
+++ b/components/falcons/getball_fetch/tick.cpp
@@ -15,12 +15,12 @@ using namespace MRA;
 
 int FalconsGetballFetch::FalconsGetballFetch::tick
 (
-    double            timestamp,   // simulation timestamp, seconds since start of simulation
-    InputType  const &input,       // input data, type generated from Input.proto
-    ParamsType const &params,      // configuration parameters, type generated from Params.proto
-    StateType        &state,       // state data, type generated from State.proto
-    OutputType       &output,      // output data, type generated from Output.proto
-    LocalType        &local        // local/diagnostics data, type generated from Local.proto
+    google::protobuf::Timestamp timestamp,   // absolute timestamp
+    InputType  const           &input,       // input data, type generated from Input.proto
+    ParamsType const           &params,      // configuration parameters, type generated from Params.proto
+    StateType                  &state,       // state data, type generated from State.proto
+    OutputType                 &output,      // output data, type generated from Output.proto
+    LocalType                  &local        // local/diagnostics data, type generated from Local.proto
 )
 {
     int error_value = 0;

--- a/components/falcons/getball_intercept/FalconsGetballIntercept.hpp
+++ b/components/falcons/getball_intercept/FalconsGetballIntercept.hpp
@@ -29,12 +29,12 @@ public:
 
     // user implementation
     int tick(
-        double            timestamp,   // simulation timestamp, seconds since start of simulation
-        InputType  const &input,       // input data, type generated from Input.proto
-        ParamsType const &params,      // configuration parameters, type generated from Params.proto
-        StateType        &state,       // state data, type generated from State.proto
-        OutputType       &output,      // output data, type generated from Output.proto
-        LocalType        &local        // local/diagnostics data, type generated from Local.proto
+        google::protobuf::Timestamp timestamp,   // absolute timestamp
+        InputType  const           &input,       // input data, type generated from Input.proto
+        ParamsType const           &params,      // configuration parameters, type generated from Params.proto
+        StateType                  &state,       // state data, type generated from State.proto
+        OutputType                 &output,      // output data, type generated from Output.proto
+        LocalType                  &local        // local/diagnostics data, type generated from Local.proto
     );
 
     // make default configuration easily accessible
@@ -49,7 +49,7 @@ public:
         StateType s;
         OutputType o;
         LocalType l;
-        return tick(0.0, InputType(), defaultParams(), s, o, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), InputType(), defaultParams(), s, o, l);
     };
 
     int tick(
@@ -59,7 +59,7 @@ public:
     {
         StateType s;
         LocalType l;
-        return tick(0.0, input, defaultParams(), s, output, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, defaultParams(), s, output, l);
     };
 
     int tick(
@@ -70,7 +70,18 @@ public:
     {
         StateType s;
         LocalType l;
-        return tick(0.0, input, params, s, output, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, params, s, output, l);
+    };
+
+    int tick(
+        InputType  const &input,
+        ParamsType const &params,
+        StateType        &state,
+        OutputType       &output,
+        LocalType        &local
+    )
+    {
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, params, state, output, local);
     };
 
 }; // class FalconsGetballIntercept

--- a/components/falcons/getball_intercept/tick.cpp
+++ b/components/falcons/getball_intercept/tick.cpp
@@ -12,12 +12,12 @@ using namespace MRA;
 
 int FalconsGetballIntercept::FalconsGetballIntercept::tick
 (
-    double            timestamp,   // simulation timestamp, seconds since start of simulation
-    InputType  const &input,       // input data, type generated from Input.proto
-    ParamsType const &params,      // configuration parameters, type generated from Params.proto
-    StateType        &state,       // state data, type generated from State.proto
-    OutputType       &output,      // output data, type generated from Output.proto
-    LocalType        &local        // local/diagnostics data, type generated from Local.proto
+    google::protobuf::Timestamp timestamp,   // absolute timestamp
+    InputType  const           &input,       // input data, type generated from Input.proto
+    ParamsType const           &params,      // configuration parameters, type generated from Params.proto
+    StateType                  &state,       // state data, type generated from State.proto
+    OutputType                 &output,      // output data, type generated from Output.proto
+    LocalType                  &local        // local/diagnostics data, type generated from Local.proto
 )
 {
     int error_value = 0;

--- a/components/falcons/trajectory_generation/FalconsTrajectoryGeneration.hpp
+++ b/components/falcons/trajectory_generation/FalconsTrajectoryGeneration.hpp
@@ -29,12 +29,12 @@ public:
 
     // user implementation
     int tick(
-        double            timestamp,   // simulation timestamp, seconds since start of simulation
-        InputType  const &input,       // input data, type generated from Input.proto
-        ParamsType const &params,      // configuration parameters, type generated from Params.proto
-        StateType        &state,       // state data, type generated from State.proto
-        OutputType       &output,      // output data, type generated from Output.proto
-        LocalType        &local        // local/diagnostics data, type generated from Local.proto
+        google::protobuf::Timestamp timestamp,   // absolute timestamp
+        InputType  const           &input,       // input data, type generated from Input.proto
+        ParamsType const           &params,      // configuration parameters, type generated from Params.proto
+        StateType                  &state,       // state data, type generated from State.proto
+        OutputType                 &output,      // output data, type generated from Output.proto
+        LocalType                  &local        // local/diagnostics data, type generated from Local.proto
     );
 
     // make default configuration easily accessible
@@ -49,7 +49,7 @@ public:
         StateType s;
         OutputType o;
         LocalType l;
-        return tick(0.0, InputType(), defaultParams(), s, o, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), InputType(), defaultParams(), s, o, l);
     };
 
     int tick(
@@ -59,7 +59,7 @@ public:
     {
         StateType s;
         LocalType l;
-        return tick(0.0, input, defaultParams(), s, output, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, defaultParams(), s, output, l);
     };
 
     int tick(
@@ -70,7 +70,18 @@ public:
     {
         StateType s;
         LocalType l;
-        return tick(0.0, input, params, s, output, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, params, s, output, l);
+    };
+
+    int tick(
+        InputType  const &input,
+        ParamsType const &params,
+        StateType        &state,
+        OutputType       &output,
+        LocalType        &local
+    )
+    {
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, params, state, output, local);
     };
 
 }; // class FalconsTrajectoryGeneration

--- a/components/falcons/velocity_control/FalconsVelocityControl.hpp
+++ b/components/falcons/velocity_control/FalconsVelocityControl.hpp
@@ -29,12 +29,12 @@ public:
 
     // user implementation
     int tick(
-        double            timestamp,   // simulation timestamp, seconds since start of simulation
-        InputType  const &input,       // input data, type generated from Input.proto
-        ParamsType const &params,      // configuration parameters, type generated from Params.proto
-        StateType        &state,       // state data, type generated from State.proto
-        OutputType       &output,      // output data, type generated from Output.proto
-        LocalType        &local        // local/diagnostics data, type generated from Local.proto
+        google::protobuf::Timestamp timestamp,   // absolute timestamp
+        InputType  const           &input,       // input data, type generated from Input.proto
+        ParamsType const           &params,      // configuration parameters, type generated from Params.proto
+        StateType                  &state,       // state data, type generated from State.proto
+        OutputType                 &output,      // output data, type generated from Output.proto
+        LocalType                  &local        // local/diagnostics data, type generated from Local.proto
     );
 
     // make default configuration easily accessible
@@ -49,7 +49,7 @@ public:
         StateType s;
         OutputType o;
         LocalType l;
-        return tick(0.0, InputType(), defaultParams(), s, o, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), InputType(), defaultParams(), s, o, l);
     };
 
     int tick(
@@ -59,7 +59,7 @@ public:
     {
         StateType s;
         LocalType l;
-        return tick(0.0, input, defaultParams(), s, output, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, defaultParams(), s, output, l);
     };
 
     int tick(
@@ -70,7 +70,18 @@ public:
     {
         StateType s;
         LocalType l;
-        return tick(0.0, input, params, s, output, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, params, s, output, l);
+    };
+
+    int tick(
+        InputType  const &input,
+        ParamsType const &params,
+        StateType        &state,
+        OutputType       &output,
+        LocalType        &local
+    )
+    {
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, params, state, output, local);
     };
 
 }; // class FalconsVelocityControl

--- a/components/falcons/velocity_control/internal/include/MRAbridge.hpp
+++ b/components/falcons/velocity_control/internal/include/MRAbridge.hpp
@@ -13,7 +13,7 @@ typedef MRA::Geometry::Pose pose;
 #include "components/falcons/velocity_control/interface/Output.pb.h"
 #include "components/falcons/velocity_control/interface/State.pb.h"
 #include "components/falcons/velocity_control/interface/Local.pb.h"
-typedef double MRA_timestamp;
+typedef google::protobuf::Timestamp MRA_timestamp;
 typedef MRA::FalconsVelocityControl::Input  MRA_InputType;
 typedef MRA::FalconsVelocityControl::Params MRA_ParamsType;
 typedef MRA::FalconsVelocityControl::State  MRA_StateType;

--- a/components/falcons/velocity_control/test.cpp
+++ b/components/falcons/velocity_control/test.cpp
@@ -165,7 +165,7 @@ TEST(FalconsVelocityControlTest, stop)
     state.mutable_velocitysetpointfcs()->set_rz(1.0);
 
     // Act
-    int error_value = m.tick(0.0, input, params, state, output, local);
+    int error_value = m.tick(input, params, state, output, local);
 
     // Assert
     EXPECT_EQ(error_value, 0);
@@ -204,8 +204,8 @@ TEST(FalconsVelocityControlTest, noHotRestart)
     state.mutable_velocitysetpointfcs()->set_rz(1.0);
 
     // Act
-    int error_value1 = m.tick(0.0, input1, params, state, output, local);
-    int error_value2 = m.tick(0.0, input2, params, state, output, local);
+    int error_value1 = m.tick(input1, params, state, output, local);
+    int error_value2 = m.tick(input2, params, state, output, local);
 
     // Assert
     EXPECT_EQ(error_value1, 0);

--- a/components/falcons/velocity_control/tick.cpp
+++ b/components/falcons/velocity_control/tick.cpp
@@ -14,12 +14,12 @@ using namespace MRA;
 
 int FalconsVelocityControl::FalconsVelocityControl::tick
 (
-    double            timestamp,   // simulation timestamp, seconds since start of simulation
-    InputType  const &input,       // input data, type generated from Input.proto
-    ParamsType const &params,      // configuration parameters, type generated from Params.proto
-    StateType        &state,       // state data, type generated from State.proto
-    OutputType       &output,      // output data, type generated from Output.proto
-    LocalType        &local        // local/diagnostics data, type generated from Local.proto
+    google::protobuf::Timestamp timestamp,   // absolute timestamp
+    InputType  const           &input,       // input data, type generated from Input.proto
+    ParamsType const           &params,      // configuration parameters, type generated from Params.proto
+    StateType                  &state,       // state data, type generated from State.proto
+    OutputType                 &output,      // output data, type generated from Output.proto
+    LocalType                  &local        // local/diagnostics data, type generated from Local.proto
 )
 {
 #ifdef DEBUG

--- a/components/robotsports/getball_fetch/RobotsportsGetballFetch.hpp
+++ b/components/robotsports/getball_fetch/RobotsportsGetballFetch.hpp
@@ -29,12 +29,12 @@ public:
 
     // user implementation
     int tick(
-        double            timestamp,   // simulation timestamp, seconds since start of simulation
-        InputType  const &input,       // input data, type generated from Input.proto
-        ParamsType const &params,      // configuration parameters, type generated from Params.proto
-        StateType        &state,       // state data, type generated from State.proto
-        OutputType       &output,      // output data, type generated from Output.proto
-        LocalType        &local        // local/diagnostics data, type generated from Local.proto
+        google::protobuf::Timestamp timestamp,   // absolute timestamp
+        InputType  const           &input,       // input data, type generated from Input.proto
+        ParamsType const           &params,      // configuration parameters, type generated from Params.proto
+        StateType                  &state,       // state data, type generated from State.proto
+        OutputType                 &output,      // output data, type generated from Output.proto
+        LocalType                  &local        // local/diagnostics data, type generated from Local.proto
     );
 
     // make default configuration easily accessible
@@ -49,7 +49,7 @@ public:
         StateType s;
         OutputType o;
         LocalType l;
-        return tick(0.0, InputType(), defaultParams(), s, o, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), InputType(), defaultParams(), s, o, l);
     };
 
     int tick(
@@ -59,7 +59,7 @@ public:
     {
         StateType s;
         LocalType l;
-        return tick(0.0, input, defaultParams(), s, output, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, defaultParams(), s, output, l);
     };
 
     int tick(
@@ -70,7 +70,18 @@ public:
     {
         StateType s;
         LocalType l;
-        return tick(0.0, input, params, s, output, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, params, s, output, l);
+    };
+
+    int tick(
+        InputType  const &input,
+        ParamsType const &params,
+        StateType        &state,
+        OutputType       &output,
+        LocalType        &local
+    )
+    {
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, params, state, output, local);
     };
 
 }; // class RobotsportsGetballFetch

--- a/components/robotsports/getball_fetch/tick.cpp
+++ b/components/robotsports/getball_fetch/tick.cpp
@@ -14,12 +14,12 @@ using namespace MRA;
 
 int RobotsportsGetballFetch::RobotsportsGetballFetch::tick
 (
-    double            timestamp,   // simulation timestamp, seconds since start of simulation
-    InputType  const &input,       // input data, type generated from Input.proto
-    ParamsType const &params,      // configuration parameters, type generated from Params.proto
-    StateType        &state,       // state data, type generated from State.proto
-    OutputType       &output,      // output data, type generated from Output.proto
-    LocalType        &local        // local/diagnostics data, type generated from Local.proto
+    google::protobuf::Timestamp timestamp,   // absolute timestamp
+    InputType  const           &input,       // input data, type generated from Input.proto
+    ParamsType const           &params,      // configuration parameters, type generated from Params.proto
+    StateType                  &state,       // state data, type generated from State.proto
+    OutputType                 &output,      // output data, type generated from Output.proto
+    LocalType                  &local        // local/diagnostics data, type generated from Local.proto
 )
 {
     int error_value = 0;

--- a/components/robotsports/getball_intercept/RobotsportsGetballIntercept.hpp
+++ b/components/robotsports/getball_intercept/RobotsportsGetballIntercept.hpp
@@ -29,12 +29,12 @@ public:
 
     // user implementation
     int tick(
-        double            timestamp,   // simulation timestamp, seconds since start of simulation
-        InputType  const &input,       // input data, type generated from Input.proto
-        ParamsType const &params,      // configuration parameters, type generated from Params.proto
-        StateType        &state,       // state data, type generated from State.proto
-        OutputType       &output,      // output data, type generated from Output.proto
-        LocalType        &local        // local/diagnostics data, type generated from Local.proto
+        google::protobuf::Timestamp timestamp,   // absolute timestamp
+        InputType  const           &input,       // input data, type generated from Input.proto
+        ParamsType const           &params,      // configuration parameters, type generated from Params.proto
+        StateType                  &state,       // state data, type generated from State.proto
+        OutputType                 &output,      // output data, type generated from Output.proto
+        LocalType                  &local        // local/diagnostics data, type generated from Local.proto
     );
 
     // make default configuration easily accessible
@@ -49,7 +49,7 @@ public:
         StateType s;
         OutputType o;
         LocalType l;
-        return tick(0.0, InputType(), defaultParams(), s, o, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), InputType(), defaultParams(), s, o, l);
     };
 
     int tick(
@@ -59,7 +59,7 @@ public:
     {
         StateType s;
         LocalType l;
-        return tick(0.0, input, defaultParams(), s, output, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, defaultParams(), s, output, l);
     };
 
     int tick(
@@ -70,7 +70,18 @@ public:
     {
         StateType s;
         LocalType l;
-        return tick(0.0, input, params, s, output, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, params, s, output, l);
+    };
+
+    int tick(
+        InputType  const &input,
+        ParamsType const &params,
+        StateType        &state,
+        OutputType       &output,
+        LocalType        &local
+    )
+    {
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, params, state, output, local);
     };
 
 }; // class RobotsportsGetballIntercept

--- a/components/robotsports/getball_intercept/tick.cpp
+++ b/components/robotsports/getball_intercept/tick.cpp
@@ -52,12 +52,12 @@ static double distanceXY(const MRA::Geometry::Position& r_pose1, const MRA::Geom
 
 int RobotsportsGetballIntercept::RobotsportsGetballIntercept::tick
 (
-    double            timestamp,   // simulation timestamp, seconds since start of simulation
-    InputType  const &input,       // input data, type generated from Input.proto
-    ParamsType const &params,      // configuration parameters, type generated from Params.proto
-    StateType        &state,       // state data, type generated from State.proto
-    OutputType       &output,      // output data, type generated from Output.proto
-    LocalType        &local        // local/diagnostics data, type generated from Local.proto
+    google::protobuf::Timestamp timestamp,   // absolute timestamp
+    InputType  const           &input,       // input data, type generated from Input.proto
+    ParamsType const           &params,      // configuration parameters, type generated from Params.proto
+    StateType                  &state,       // state data, type generated from State.proto
+    OutputType                 &output,      // output data, type generated from Output.proto
+    LocalType                  &local        // local/diagnostics data, type generated from Local.proto
 )
 {
 #ifdef DEBUG

--- a/components/robotsports/proof_is_alive/RobotsportsProofIsAlive.hpp
+++ b/components/robotsports/proof_is_alive/RobotsportsProofIsAlive.hpp
@@ -29,12 +29,12 @@ public:
 
     // user implementation
     int tick(
-        double            timestamp,   // simulation timestamp, seconds since start of simulation
-        InputType  const &input,       // input data, type generated from Input.proto
-        ParamsType const &params,      // configuration parameters, type generated from Params.proto
-        StateType        &state,       // state data, type generated from State.proto
-        OutputType       &output,      // output data, type generated from Output.proto
-        LocalType        &local        // local/diagnostics data, type generated from Local.proto
+        google::protobuf::Timestamp timestamp,   // absolute timestamp
+        InputType  const           &input,       // input data, type generated from Input.proto
+        ParamsType const           &params,      // configuration parameters, type generated from Params.proto
+        StateType                  &state,       // state data, type generated from State.proto
+        OutputType                 &output,      // output data, type generated from Output.proto
+        LocalType                  &local        // local/diagnostics data, type generated from Local.proto
     );
 
     // make default configuration easily accessible
@@ -49,7 +49,7 @@ public:
         StateType s;
         OutputType o;
         LocalType l;
-        return tick(0.0, InputType(), defaultParams(), s, o, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), InputType(), defaultParams(), s, o, l);
     };
 
     int tick(
@@ -59,7 +59,7 @@ public:
     {
         StateType s;
         LocalType l;
-        return tick(0.0, input, defaultParams(), s, output, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, defaultParams(), s, output, l);
     };
 
     int tick(
@@ -70,7 +70,18 @@ public:
     {
         StateType s;
         LocalType l;
-        return tick(0.0, input, params, s, output, l);
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, params, s, output, l);
+    };
+
+    int tick(
+        InputType  const &input,
+        ParamsType const &params,
+        StateType        &state,
+        OutputType       &output,
+        LocalType        &local
+    )
+    {
+        return tick(google::protobuf::util::TimeUtil::GetCurrentTime(), input, params, state, output, local);
     };
 
 }; // class RobotsportsProofIsAlive

--- a/components/robotsports/proof_is_alive/interface/State.proto
+++ b/components/robotsports/proof_is_alive/interface/State.proto
@@ -18,8 +18,6 @@ message State
 
     ProofIsAlivePhase phase = 1;
     MRA.Datatypes.Pose requested_position = 2;
-    //# google.protobuf.Timestamp timestamp_start_phase = 3;
-    double timestamp_start_phase = 3;
-
+    google.protobuf.Timestamp timestamp_start_phase = 3;
 }
 

--- a/components/robotsports/proof_is_alive/test.cpp
+++ b/components/robotsports/proof_is_alive/test.cpp
@@ -30,9 +30,7 @@ TEST(RobotsportsProofIsAliveTest, basicTick)
 google::protobuf::Timestamp timeFromDouble(google::protobuf::Timestamp const &t0, double dt)
 {
     google::protobuf::Timestamp result = t0;
-    google::protobuf::Duration duration;
-    duration.set_seconds(0);
-    duration.set_nanos(static_cast<int32_t>(dt * 1e9));
+    google::protobuf::Duration duration = google::protobuf::util::TimeUtil::NanosecondsToDuration((int64_t)(1e9 * dt));
     return result + duration;
 }
 

--- a/components/robotsports/proof_is_alive/test.cpp
+++ b/components/robotsports/proof_is_alive/test.cpp
@@ -26,6 +26,16 @@ TEST(RobotsportsProofIsAliveTest, basicTick)
     EXPECT_EQ(error_value, 0);
 }
 
+// helper function for adding some seconds to a google timestamp
+google::protobuf::Timestamp timeFromDouble(google::protobuf::Timestamp const &t0, double dt)
+{
+    google::protobuf::Timestamp result = t0;
+    google::protobuf::Duration duration;
+    duration.set_seconds(0);
+    duration.set_nanos(static_cast<int32_t>(dt * 1e9));
+    return result + duration;
+}
+
 // Turn test check if all target positions are correct
 TEST(RobotsportsProofIsAliveTest, turnTest)
 {
@@ -36,11 +46,12 @@ TEST(RobotsportsProofIsAliveTest, turnTest)
     auto state = RobotsportsProofIsAlive::State();
     auto local = RobotsportsProofIsAlive::Local();
     auto params = m.defaultParams();
+    google::protobuf::Timestamp t0 = google::protobuf::util::TimeUtil::GetCurrentTime(); // arbitrary
 
     input.mutable_worldstate()->mutable_robot()->set_active(true);
 
     // start in middle, expect turn to left
-    int error_value = m.tick(0.0, input, params, state, output, local);
+    int error_value = m.tick(timeFromDouble(t0, 0.0), input, params, state, output, local);
 
     // Asserts for turn from middle to left position
     EXPECT_EQ(error_value, 0);
@@ -52,7 +63,7 @@ TEST(RobotsportsProofIsAliveTest, turnTest)
     // start left, expect turn to right
     input.mutable_worldstate()->mutable_robot()->set_active(true);
     input.mutable_worldstate()->mutable_robot()->mutable_position()->set_rz(output.target().position().rz());
-    error_value = m.tick(1.0, input, params, state, output, local);
+    error_value = m.tick(timeFromDouble(t0, 1.0), input, params, state, output, local);
     // Asserts for turn from left position to right position
     EXPECT_EQ(error_value, 0);
     EXPECT_EQ(output.actionresult(), MRA::Datatypes::RUNNING);
@@ -63,7 +74,7 @@ TEST(RobotsportsProofIsAliveTest, turnTest)
     // start right, expect turn to middle position (starting postion)
     input.mutable_worldstate()->mutable_robot()->set_active(true);
     input.mutable_worldstate()->mutable_robot()->mutable_position()->set_rz(output.target().position().rz());
-    error_value = m.tick(2.0, input, params, state, output, local);
+    error_value = m.tick(timeFromDouble(t0, 2.0), input, params, state, output, local);
     // Asserts for turn from right position to middle (starting) position
     EXPECT_EQ(error_value, 0);
     EXPECT_EQ(output.actionresult(), MRA::Datatypes::RUNNING);
@@ -82,11 +93,12 @@ TEST(RobotsportsProofIsAliveTest, timeoutTest)
     auto state = RobotsportsProofIsAlive::State();
     auto local = RobotsportsProofIsAlive::Local();
     auto params = m.defaultParams();
+    google::protobuf::Timestamp t0 = google::protobuf::util::TimeUtil::GetCurrentTime(); // arbitrary
 
     input.mutable_worldstate()->mutable_robot()->set_active(true);
 
     // start in middle, expect turn to left
-    int error_value = m.tick(0.0, input, params, state, output, local);
+    int error_value = m.tick(timeFromDouble(t0, 0.0), input, params, state, output, local);
 
     // Asserts for turn from middle to left position
     EXPECT_EQ(error_value, 0);
@@ -96,7 +108,7 @@ TEST(RobotsportsProofIsAliveTest, timeoutTest)
     EXPECT_NEAR(output.target().position().rz(), params.angle_in_degrees()*(M_PI/180), 1e-4);
 
     // start left, expect turn to right
-    error_value = m.tick(11.0, input, params, state, output, local);
+    error_value = m.tick(timeFromDouble(t0, 11.0), input, params, state, output, local);
     // Asserts for turn from left position to right position
     EXPECT_EQ(error_value, 0);
     EXPECT_EQ(output.actionresult(), MRA::Datatypes::FAILED);

--- a/components/robotsports/proof_is_alive/tick.cpp
+++ b/components/robotsports/proof_is_alive/tick.cpp
@@ -53,11 +53,12 @@ int RobotsportsProofIsAlive::RobotsportsProofIsAlive::tick
 
 	if (state.phase() == StateType::TO_BE_STARTED) 
 	{
-	    state.set_timestamp_start_phase(timestamp);		
+        *state.mutable_timestamp_start_phase() = timestamp;
 	}
 
 	double max_time_per_phase = params.max_time_per_phase();
-	if (timestamp - state.timestamp_start_phase() > max_time_per_phase)
+    google::protobuf::Duration duration_phase = google::protobuf::util::TimeUtil::NanosecondsToDuration((int64_t)(1e9 * max_time_per_phase));
+	if (timestamp - state.timestamp_start_phase() > duration_phase)
 	{
 		// time out: to long before reaching new state
 #ifdef DEBUG
@@ -77,7 +78,7 @@ int RobotsportsProofIsAlive::RobotsportsProofIsAlive::tick
 
 		if (state.phase() == StateType::TO_BE_STARTED)
 		{
-		    state.set_timestamp_start_phase(timestamp);		
+            *state.mutable_timestamp_start_phase() = timestamp;
 		    state.mutable_requested_position()->set_x(ws.robot().position().x());
 		    state.mutable_requested_position()->set_y(ws.robot().position().y());
 		    state.mutable_requested_position()->set_rz(ws.robot().position().rz() + rotation_angle_rad);
@@ -88,7 +89,7 @@ int RobotsportsProofIsAlive::RobotsportsProofIsAlive::tick
 			if (min_angle(state.requested_position().rz(), ws.robot().position().rz()) < deg2rad(params.angle_tolerance_deg()))
 			{
 				// Robot is turned to the left
-			    state.set_timestamp_start_phase(timestamp);
+                *state.mutable_timestamp_start_phase() = timestamp;
 		    	state.mutable_requested_position()->set_x(ws.robot().position().x());
 		    	state.mutable_requested_position()->set_y(ws.robot().position().y());
 		    	state.mutable_requested_position()->set_rz(ws.robot().position().rz() - 2 * rotation_angle_rad);
@@ -99,7 +100,7 @@ int RobotsportsProofIsAlive::RobotsportsProofIsAlive::tick
 		{
 			if (min_angle(state.requested_position().rz(), ws.robot().position().rz()) < deg2rad(params.angle_tolerance_deg()))
 			{
-			    state.set_timestamp_start_phase(timestamp);
+                *state.mutable_timestamp_start_phase() = timestamp;
 		    	state.mutable_requested_position()->set_x(ws.robot().position().x());
 		    	state.mutable_requested_position()->set_y(ws.robot().position().y());
 		    	state.mutable_requested_position()->set_rz(ws.robot().position().rz() + rotation_angle_rad);
@@ -110,7 +111,7 @@ int RobotsportsProofIsAlive::RobotsportsProofIsAlive::tick
 		{
 			if (min_angle(state.requested_position().rz(), ws.robot().position().rz()) < deg2rad(params.angle_tolerance_deg()))
 			{
-			    state.set_timestamp_start_phase(timestamp);
+                *state.mutable_timestamp_start_phase() = timestamp;
 		    	state.mutable_requested_position()->set_x(ws.robot().position().x());
 		    	state.mutable_requested_position()->set_y(ws.robot().position().y());
 		    	state.mutable_requested_position()->set_rz(ws.robot().position().rz() - rotation_angle_rad);

--- a/components/robotsports/proof_is_alive/tick.cpp
+++ b/components/robotsports/proof_is_alive/tick.cpp
@@ -32,12 +32,12 @@ static double deg2rad(double angle_in_degrees)
 // -----------------------------------------------------------------------------
 int RobotsportsProofIsAlive::RobotsportsProofIsAlive::tick
 (
-    double            timestamp,   // simulation timestamp, seconds since start of simulation
-    InputType  const &input,       // input data, type generated from Input.proto
-    ParamsType const &params,      // configuration parameters, type generated from Params.proto
-    StateType        &state,       // state data, type generated from State.proto
-    OutputType       &output,      // output data, type generated from Output.proto
-    LocalType        &local        // local/diagnostics data, type generated from Local.proto
+    google::protobuf::Timestamp timestamp,   // absolute timestamp
+    InputType  const           &input,       // input data, type generated from Input.proto
+    ParamsType const           &params,      // configuration parameters, type generated from Params.proto
+    StateType                  &state,       // state data, type generated from State.proto
+    OutputType                 &output,      // output data, type generated from Output.proto
+    LocalType                  &local        // local/diagnostics data, type generated from Local.proto
 )
 {
 #ifdef DEBUG


### PR DESCRIPTION
The tick interface has a timestamp as first input.

It used to be double, now it becomes google protobuf timestamp.

For MRA_logger, we need to fix this. I cherry-picked relevant commits out of that branch into this branch/PR. This will cause the following PR's to be cleaner.

Edit: some non-trivial changes were needed in robotsports/proof_is_alive, because it actually uses timestamps and has a nice test suite. So Jurge, please review.