### PR TITLE
Cmakefixes: add missing dependencies on MRA-datatypes

### DIFF
--- a/libraries/geometry/CMakeLists.txt
+++ b/libraries/geometry/CMakeLists.txt
@@ -12,3 +12,4 @@ add_library(MRA-libraries-geometry
 target_include_directories(MRA-libraries-geometry PUBLIC
 	${MRA_BINARY_DIR}
 )
+add_dependencies(MRA-libraries-geometry MRA-datatypes)

--- a/libraries/logging/CMakeLists.txt
+++ b/libraries/logging/CMakeLists.txt
@@ -21,3 +21,4 @@ target_include_directories(MRA-libraries-logging PUBLIC
 		${CMAKE_SOURCE_DIR}/base
 )
 target_link_libraries(MRA-libraries-logging MRA-base nlohmann_json::nlohmann_json rt spdlog::spdlog)
+add_dependencies(MRA-libraries-logging MRA-datatypes)


### PR DESCRIPTION
Added  missing dependencies on MRA-datatypes in CMakeLists.txt.

This PR closes #4 
A new issue (#30) is created to remove the not preferred protobuf generation  at toplevel,

