### PR TITLE
use MRA_SOURCE_DIR iso CMAKE_SOURCE_DIR

### DIFF
--- a/base/codegen/template_CMakeLists.txt
+++ b/base/codegen/template_CMakeLists.txt
@@ -6,8 +6,8 @@ add_library(MRA-components-CMAKE_COMPONENT_LIBRARY_NAME
 )
 target_include_directories(MRA-components-CMAKE_COMPONENT_LIBRARY_NAME PUBLIC
     ${MRA_SOURCE_DIR}/libraries/logging
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/base
+    ${MRA_SOURCE_DIR}
+    ${MRA_SOURCE_DIR}/base
     ${CMAKE_CURRENT_BINARY_DIR}/interface)
 target_link_libraries(MRA-components-CMAKE_COMPONENT_LIBRARY_NAME MRA-libraries MRA-components-proto MRA-base nlohmann_json::nlohmann_json)
 

--- a/components/falcons/getball/CMakeLists.txt
+++ b/components/falcons/getball/CMakeLists.txt
@@ -6,8 +6,8 @@ add_library(MRA-components-falcons-getball
 )
 target_include_directories(MRA-components-falcons-getball PUBLIC
     ${MRA_SOURCE_DIR}/libraries/logging
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/base
+    ${MRA_SOURCE_DIR}
+    ${MRA_SOURCE_DIR}/base
     ${CMAKE_CURRENT_BINARY_DIR}/interface)
 target_link_libraries(MRA-components-falcons-getball MRA-libraries MRA-components-proto MRA-base nlohmann_json::nlohmann_json)
 

--- a/components/falcons/getball_fetch/CMakeLists.txt
+++ b/components/falcons/getball_fetch/CMakeLists.txt
@@ -6,8 +6,8 @@ add_library(MRA-components-falcons-getball-fetch
 )
 target_include_directories(MRA-components-falcons-getball-fetch PUBLIC
     ${MRA_SOURCE_DIR}/libraries/logging
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/base
+    ${MRA_SOURCE_DIR}
+    ${MRA_SOURCE_DIR}/base
     ${CMAKE_CURRENT_BINARY_DIR}/interface)
 target_link_libraries(MRA-components-falcons-getball-fetch MRA-libraries MRA-components-proto MRA-base nlohmann_json::nlohmann_json)
 

--- a/components/falcons/getball_intercept/CMakeLists.txt
+++ b/components/falcons/getball_intercept/CMakeLists.txt
@@ -6,8 +6,8 @@ add_library(MRA-components-falcons-getball-intercept
 )
 target_include_directories(MRA-components-falcons-getball-intercept PUBLIC
     ${MRA_SOURCE_DIR}/libraries/logging
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/base
+    ${MRA_SOURCE_DIR}
+    ${MRA_SOURCE_DIR}/base
     ${CMAKE_CURRENT_BINARY_DIR}/interface)
 target_link_libraries(MRA-components-falcons-getball-intercept MRA-libraries MRA-components-proto MRA-base nlohmann_json::nlohmann_json)
 

--- a/components/falcons/test_mra_logger/CMakeLists.txt
+++ b/components/falcons/test_mra_logger/CMakeLists.txt
@@ -8,8 +8,8 @@ add_library(MRA-components-falcons-test-mra-logger
 )
 target_include_directories(MRA-components-falcons-test-mra-logger PUBLIC
     ${MRA_SOURCE_DIR}/libraries/logging
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/base
+    ${MRA_SOURCE_DIR}
+    ${MRA_SOURCE_DIR}/base
     ${CMAKE_CURRENT_BINARY_DIR}/interface)
 target_link_libraries(MRA-components-falcons-test-mra-logger MRA-libraries MRA-components-proto MRA-base nlohmann_json::nlohmann_json)
 

--- a/components/falcons/trajectory_generation/CMakeLists.txt
+++ b/components/falcons/trajectory_generation/CMakeLists.txt
@@ -6,8 +6,8 @@ add_library(MRA-components-falcons-trajectory-generation
 )
 target_include_directories(MRA-components-falcons-trajectory-generation PUBLIC
     ${MRA_SOURCE_DIR}/libraries/logging
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/base
+    ${MRA_SOURCE_DIR}
+    ${MRA_SOURCE_DIR}/base
     ${CMAKE_CURRENT_BINARY_DIR}/interface)
 target_link_libraries(MRA-components-falcons-trajectory-generation MRA-libraries MRA-components-proto MRA-base nlohmann_json::nlohmann_json)
 

--- a/components/falcons/velocity_control/CMakeLists.txt
+++ b/components/falcons/velocity_control/CMakeLists.txt
@@ -17,8 +17,8 @@ add_library(MRA-components-falcons-velocity-control
 )
 target_include_directories(MRA-components-falcons-velocity-control PUBLIC
     ${MRA_SOURCE_DIR}/libraries/logging
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/base
+    ${MRA_SOURCE_DIR}
+    ${MRA_SOURCE_DIR}/base
     ${CMAKE_CURRENT_BINARY_DIR}/interface
     ${CMAKE_CURRENT_SOURCE_DIR}/internal/include
 )

--- a/components/robotsports/getball_fetch/CMakeLists.txt
+++ b/components/robotsports/getball_fetch/CMakeLists.txt
@@ -6,8 +6,8 @@ add_library(MRA-components-robotsports-getball-fetch
 )
 target_include_directories(MRA-components-robotsports-getball-fetch PUBLIC
     ${MRA_SOURCE_DIR}/libraries/logging
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/base
+    ${MRA_SOURCE_DIR}
+    ${MRA_SOURCE_DIR}/base
     ${CMAKE_CURRENT_BINARY_DIR}/interface)
 target_link_libraries(MRA-components-robotsports-getball-fetch MRA-libraries MRA-components-proto MRA-base nlohmann_json::nlohmann_json)
 

--- a/components/robotsports/getball_intercept/CMakeLists.txt
+++ b/components/robotsports/getball_intercept/CMakeLists.txt
@@ -6,8 +6,8 @@ add_library(MRA-components-robotsports-getball-intercept
 )
 target_include_directories(MRA-components-robotsports-getball-intercept PUBLIC
     ${MRA_SOURCE_DIR}/libraries/logging
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/base
+    ${MRA_SOURCE_DIR}
+    ${MRA_SOURCE_DIR}/base
     ${CMAKE_CURRENT_BINARY_DIR}/interface)
 target_link_libraries(MRA-components-robotsports-getball-intercept MRA-libraries MRA-components-proto MRA-base nlohmann_json::nlohmann_json)
 

--- a/components/robotsports/proof_is_alive/CMakeLists.txt
+++ b/components/robotsports/proof_is_alive/CMakeLists.txt
@@ -6,8 +6,8 @@ add_library(MRA-components-robotsports-proof-is-alive
 )
 target_include_directories(MRA-components-robotsports-proof-is-alive PUBLIC
     ${MRA_SOURCE_DIR}/libraries/logging
-    ${CMAKE_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/base
+    ${MRA_SOURCE_DIR}
+    ${MRA_SOURCE_DIR}/base
     ${CMAKE_CURRENT_BINARY_DIR}/interface)
 target_link_libraries(MRA-components-robotsports-proof-is-alive MRA-libraries MRA-components-proto MRA-base nlohmann_json::nlohmann_json)
 

--- a/libraries/logging/CMakeLists.txt
+++ b/libraries/logging/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library(MRA-libraries-logging
 
 target_include_directories(MRA-libraries-logging PUBLIC
 		${MRA_BINARY_DIR}
-		${CMAKE_SOURCE_DIR}/base
+		${MRA_SOURCE_DIR}/base
 )
 target_link_libraries(MRA-libraries-logging MRA-base nlohmann_json::nlohmann_json rt spdlog::spdlog)
 add_dependencies(MRA-libraries-logging MRA-datatypes)


### PR DESCRIPTION
Use MRA_SOURCE_DIR iso CMAKE_SOURCE_DIR.
MRA_SOURCE_DIR is needed to allow MRA being a submodule with CMake build environment
